### PR TITLE
Add peft dependency and LoRA notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    ```bash
    python -m pip install --upgrade pip
    pip install -r requirements.txt
+   # в том числе библиотека `peft` для поддержки LoRA
    ```
 3. Установите PyTorch, подходящий для вашей системы. Пример для CUDA 12.1:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.32.4
 tqdm==4.67.0
 numpy==1.26.4
 packaging==25.0
+peft==0.10.0

--- a/src/pipeline_factory.py
+++ b/src/pipeline_factory.py
@@ -83,6 +83,11 @@ def create_pipeline(cfg):
 
     # Inject LoRA if present
     if getattr(cfg, 'lora_model', None):
+        try:
+            import peft  # noqa: F401
+        except Exception as e:
+            raise RuntimeError("Package 'peft' is required for LoRA support. Install it with 'pip install peft'.") from e
+
         lora_path = cfg.lora_model
         if not os.path.isabs(lora_path):
             lora_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, lora_path))


### PR DESCRIPTION
## Summary
- add `peft` to requirements
- mention `peft` in installation instructions
- check for `peft` in `create_pipeline` when loading LoRA

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f28e3ee78832dbeabfd2be97f3aec